### PR TITLE
DOCX renderer + Bruno collection + worker rebuild target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WORKER_PYTHON_CONTAINER=worker-python
 .PHONY: install-uv install-local lint bump-patch bump-minor \
         up down logs-api logs-listener logs-consumer logs-worker-python \
         build build-api build-consumer build-worker-python \
-        build-generation-render-worker \
+        build-generation-render-worker rebuild-generation-render-worker \
         migrate stamp-db list-revision upgrade-revision \
         test coverage clean clean-cache help
 
@@ -85,7 +85,10 @@ build-consumer: ## Lance la construction de l'image Docker consumer JS
 build-listener: ## Lance la construction de l'image Docker du listener de l'api
 	docker compose build worker-python
 
-build-generation-render-worker: ## Reconstruit l'image du worker generation-render sans cache
+build-generation-render-worker: ## Lance la construction de l'image Docker du worker generation-render
+	docker compose build generation-render-worker
+
+rebuild-generation-render-worker: ## Reconstruit l'image du worker generation-render sans cache (quand une dépendance change)
 	docker compose build --no-cache generation-render-worker
 
 migration-stamp-db: ## Change le pointeur alembic à une révision particulière

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ WORKER_PYTHON_CONTAINER=worker-python
 .PHONY: install-uv install-local lint bump-patch bump-minor \
         up down logs-api logs-listener logs-consumer logs-worker-python \
         build build-api build-consumer build-worker-python \
+        build-generation-render-worker \
         migrate stamp-db list-revision upgrade-revision \
         test coverage clean clean-cache help
 
@@ -73,7 +74,7 @@ logs-db: ## Affiche les logs de la base de données
 logs-rabbitmq: ## Affiche les logs de RabbitMQ
 	docker compose logs -f broker
 
-build: build-api build-consumer build-listener ## Lance la construction de toutes les images Docker
+build: build-api build-consumer build-listener build-generation-render-worker ## Lance la construction de toutes les images Docker
 
 build-api: ## Lance la construction de l'image Docker API
 	docker compose build api
@@ -83,6 +84,9 @@ build-consumer: ## Lance la construction de l'image Docker consumer JS
 
 build-listener: ## Lance la construction de l'image Docker du listener de l'api
 	docker compose build worker-python
+
+build-generation-render-worker: ## Reconstruit l'image du worker generation-render sans cache
+	docker compose build --no-cache generation-render-worker
 
 migration-stamp-db: ## Change le pointeur alembic à une révision particulière
 	@read -p "ID de la révision : " revision; \

--- a/bruno/Generation render/01 Upload docx template.bru
+++ b/bruno/Generation render/01 Upload docx template.bru
@@ -1,0 +1,32 @@
+meta {
+  name: 01 Upload docx template
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/storage/upload
+  body: multipartForm
+  auth: basic
+}
+
+auth:basic {
+  username: {{client_id}}
+  password: {{client_secret}}
+}
+
+body:multipart-form {
+  file: @file(../api/docs/examples/generation-render/test_template.docx)
+}
+
+script:post-response {
+  if (res.getStatus() === 201) {
+    bru.setEnvVar("file_id", res.getBody().file_id);
+  }
+}
+
+docs {
+  Upload du template .docx vers S3 (MinIO en local).
+  Le file_id renvoye est automatiquement stocke dans la variable d'environnement `file_id`
+  pour etre reutilise par la requete suivante.
+}

--- a/bruno/Generation render/01 Upload docx template.bru
+++ b/bruno/Generation render/01 Upload docx template.bru
@@ -20,7 +20,7 @@ body:multipart-form {
 }
 
 script:post-response {
-  if (res.getStatus() === 201) {
+  if (res.getStatus() >= 200 && res.getStatus() < 300) {
     bru.setEnvVar("file_id", res.getBody().file_id);
   }
 }

--- a/bruno/Generation render/02 Create render task.bru
+++ b/bruno/Generation render/02 Create render task.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 02 Create render task
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/v1/services/{{service}}/tasks
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: {{client_id}}
+  password: {{client_secret}}
+}
+
+body:json {
+  {
+    "body": {
+      "file_id": "{{file_id}}",
+      "data": {
+        "nom": "Dupont",
+        "ville": "Nice",
+        "is_admin": true,
+        "items": ["dossier-001", "dossier-002", "dossier-003"]
+      }
+    }
+  }
+}
+
+script:post-response {
+  if (res.getStatus() === 201) {
+    bru.setEnvVar("task_id", res.getBody().data.task_id);
+  }
+}
+
+docs {
+  Cree une tache de rendu docx. Le `file_id` provient de la requete 01.
+  Le `task_id` renvoye est stocke dans l'environnement pour etre poll par la requete 03.
+}

--- a/bruno/Generation render/02 Create render task.bru
+++ b/bruno/Generation render/02 Create render task.bru
@@ -30,7 +30,7 @@ body:json {
 }
 
 script:post-response {
-  if (res.getStatus() === 201) {
+  if (res.getStatus() >= 200 && res.getStatus() < 300) {
     bru.setEnvVar("task_id", res.getBody().data.task_id);
   }
 }

--- a/bruno/Generation render/03 Get task status.bru
+++ b/bruno/Generation render/03 Get task status.bru
@@ -1,0 +1,22 @@
+meta {
+  name: 03 Get task status
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/v1/services/{{service}}/tasks/{{task_id}}
+  body: none
+  auth: basic
+}
+
+auth:basic {
+  username: {{client_id}}
+  password: {{client_secret}}
+}
+
+docs {
+  Poll le statut de la tache. A relancer plusieurs fois jusqu'a obtenir status "success".
+  Quand la tache reussit, `data.result.download_url` contient une URL presignee S3
+  permettant de telecharger le fichier rendu.
+}

--- a/bruno/Generation render/04 Create render task - missing keys.bru
+++ b/bruno/Generation render/04 Create render task - missing keys.bru
@@ -1,0 +1,39 @@
+meta {
+  name: 04 Create render task - missing keys
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/v1/services/{{service}}/tasks
+  body: json
+  auth: basic
+}
+
+auth:basic {
+  username: {{client_id}}
+  password: {{client_secret}}
+}
+
+body:json {
+  {
+    "body": {
+      "file_id": "{{file_id}}",
+      "data": {
+        "nom": "Dupont"
+      }
+    }
+  }
+}
+
+script:post-response {
+  if (res.getStatus() === 201) {
+    bru.setEnvVar("task_id", res.getBody().data.task_id);
+  }
+}
+
+docs {
+  Variante pour verifier le comportement quand des placeholders du template ne sont
+  pas fournis. Attendu : la tache reussit, mais `result.warnings` liste les cles manquantes.
+  Relance ensuite "03 Get task status" pour observer le resultat.
+}

--- a/bruno/Generation render/04 Create render task - missing keys.bru
+++ b/bruno/Generation render/04 Create render task - missing keys.bru
@@ -27,7 +27,7 @@ body:json {
 }
 
 script:post-response {
-  if (res.getStatus() === 201) {
+  if (res.getStatus() >= 200 && res.getStatus() < 300) {
     bru.setEnvVar("task_id", res.getBody().data.task_id);
   }
 }

--- a/bruno/Health check.bru
+++ b/bruno/Health check.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Health check
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/internal/health
+  body: none
+  auth: none
+}

--- a/bruno/List services.bru
+++ b/bruno/List services.bru
@@ -1,0 +1,11 @@
+meta {
+  name: List services
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1/services
+  body: none
+  auth: none
+}

--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "async-api",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/bruno/environments/Local.bru
+++ b/bruno/environments/Local.bru
@@ -2,8 +2,8 @@ vars {
   baseUrl: http://localhost:8080
   client_id: client1
   service: generation-render
-  file_id: client1/f75cfe9f-71c4-45ea-843e-4d9468c44c5e/test_template.docx
-  task_id: 7d9549e2-660d-4d33-b7fc-4f502134db7e
+  file_id:
+  task_id:
 }
 vars:secret [
   client_secret

--- a/bruno/environments/Local.bru
+++ b/bruno/environments/Local.bru
@@ -1,0 +1,10 @@
+vars {
+  baseUrl: http://localhost:8080
+  client_id: client1
+  service: generation-render
+  file_id: client1/f75cfe9f-71c4-45ea-843e-4d9468c44c5e/test_template.docx
+  task_id: 7d9549e2-660d-4d33-b7fc-4f502134db7e
+}
+vars:secret [
+  client_secret
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,3 +168,10 @@ sort = "-miss"
 
 [tool.pytest.ini_options]
 addopts = "--ignore=workers/python"
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.13"
+exclude = ["workers", ".venv"]
+typeCheckingMode = "off"

--- a/workers/python/demo/pyproject.toml
+++ b/workers/python/demo/pyproject.toml
@@ -8,3 +8,10 @@ dependencies = [
     "loguru>=0.7.3",
     "mic-worker==0.1.2",
 ]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.13"
+exclude = [".venv"]
+typeCheckingMode = "off"

--- a/workers/python/generation-render/pyproject.toml
+++ b/workers/python/generation-render/pyproject.toml
@@ -13,3 +13,10 @@ dependencies = [
     "pytest-asyncio>=1.3.0",
     "relatorio>=0.10",
 ]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.13"
+exclude = [".venv"]
+typeCheckingMode = "off"

--- a/workers/python/generation-render/src/renderers/__init__.py
+++ b/workers/python/generation-render/src/renderers/__init__.py
@@ -1,5 +1,6 @@
 from src.renderers.base import RenderResult, TemplateRenderer
+from src.renderers.docx import DocxRenderer
 from src.renderers.odt import OdtRenderer
 from src.renderers.registry import get_renderer
 
-__all__ = ["OdtRenderer", "RenderResult", "TemplateRenderer", "get_renderer"]
+__all__ = ["DocxRenderer", "OdtRenderer", "RenderResult", "TemplateRenderer", "get_renderer"]

--- a/workers/python/generation-render/src/renderers/base.py
+++ b/workers/python/generation-render/src/renderers/base.py
@@ -10,7 +10,7 @@ class RenderResult:
 
 class TemplateRenderer(ABC):
     @abstractmethod
-    def render(self, template_content: bytes, data: dict[str, str]) -> RenderResult:
+    def render(self, template_content: bytes, data: dict[str, object]) -> RenderResult:
         """Replace placeholders in the template with the provided data.
 
         Args:

--- a/workers/python/generation-render/src/renderers/docx.py
+++ b/workers/python/generation-render/src/renderers/docx.py
@@ -1,0 +1,27 @@
+from io import BytesIO
+
+from docxtpl import DocxTemplate
+from jinja2 import DebugUndefined, Environment
+from loguru import logger
+
+from src.renderers.base import RenderResult, TemplateRenderer
+
+
+class DocxRenderer(TemplateRenderer):
+    def render(self, template_content: bytes, data: dict[str, object]) -> RenderResult:
+        template = DocxTemplate(BytesIO(template_content))
+        # DOCX isn't HTML; docxtpl handles XML escaping itself at render time.
+        jinja_env = Environment(undefined=DebugUndefined)  # noqa: S701
+
+        expected_keys = template.get_undeclared_template_variables(jinja_env=jinja_env)
+        missing_keys = sorted(expected_keys - data.keys())
+
+        template.render(data, jinja_env=jinja_env)
+        output = BytesIO()
+        template.save(output)
+
+        warnings = [f"La donnée pour '{key}' n'est pas définie" for key in missing_keys]
+        if warnings:
+            logger.warning(f"Missing keys: {missing_keys}")
+
+        return RenderResult(content=output.getvalue(), warnings=warnings)

--- a/workers/python/generation-render/src/renderers/docx.py
+++ b/workers/python/generation-render/src/renderers/docx.py
@@ -10,7 +10,6 @@ from src.renderers.base import RenderResult, TemplateRenderer
 class DocxRenderer(TemplateRenderer):
     def render(self, template_content: bytes, data: dict[str, object]) -> RenderResult:
         template = DocxTemplate(BytesIO(template_content))
-        # DOCX isn't HTML; docxtpl handles XML escaping itself at render time.
         jinja_env = Environment(undefined=DebugUndefined)  # noqa: S701
 
         expected_keys = template.get_undeclared_template_variables(jinja_env=jinja_env)

--- a/workers/python/generation-render/src/renderers/registry.py
+++ b/workers/python/generation-render/src/renderers/registry.py
@@ -1,8 +1,10 @@
 from src.renderers.base import TemplateRenderer
+from src.renderers.docx import DocxRenderer
 from src.renderers.odt import OdtRenderer
 
 RENDERERS: dict[str, type[TemplateRenderer]] = {
     ".odt": OdtRenderer,
+    ".docx": DocxRenderer,
 }
 
 

--- a/workers/python/generation-render/tests/test_docx_renderer.py
+++ b/workers/python/generation-render/tests/test_docx_renderer.py
@@ -1,0 +1,131 @@
+import json
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+from docx import Document
+from src.renderers.docx import DocxRenderer
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_template() -> bytes:
+    return (FIXTURES_DIR / "test_template.docx").read_bytes()
+
+
+def _load_data() -> dict:
+    return json.loads((FIXTURES_DIR / "test_data.json").read_text())
+
+
+def _extract_text(docx_bytes: bytes) -> str:
+    doc = Document(BytesIO(docx_bytes))
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+class TestDocxRendererHappyPath:
+    def test_simple_placeholders_replaced(self) -> None:
+        renderer = DocxRenderer()
+
+        result = renderer.render(_load_template(), _load_data())
+
+        text = _extract_text(result.content)
+        assert "Dupont" in text
+        assert "Nice" in text
+
+    def test_conditional_block_rendered(self) -> None:
+        renderer = DocxRenderer()
+
+        result = renderer.render(_load_template(), _load_data())
+
+        text = _extract_text(result.content)
+        assert "Vous etes administrateur" in text
+
+    def test_iterative_block_rendered(self) -> None:
+        renderer = DocxRenderer()
+
+        result = renderer.render(_load_template(), _load_data())
+
+        text = _extract_text(result.content)
+        assert "dossier-001" in text
+        assert "dossier-002" in text
+        assert "dossier-003" in text
+
+    def test_no_warnings_when_all_keys_present(self) -> None:
+        renderer = DocxRenderer()
+
+        result = renderer.render(_load_template(), _load_data())
+
+        assert result.warnings == []
+
+    def test_output_is_valid_docx(self) -> None:
+        renderer = DocxRenderer()
+
+        result = renderer.render(_load_template(), _load_data())
+
+        with zipfile.ZipFile(BytesIO(result.content), "r") as z:
+            names = z.namelist()
+            assert "word/document.xml" in names
+            assert "[Content_Types].xml" in names
+
+
+class TestDocxRendererMissingKeys:
+    def test_missing_simple_key_keeps_placeholder(self) -> None:
+        """DebugUndefined renders `{{ key }}` for missing placeholders."""
+        renderer = DocxRenderer()
+
+        result = renderer.render(
+            _load_template(),
+            {"nom": "Dupont", "is_admin": True, "items": []},
+        )
+
+        text = _extract_text(result.content)
+        assert "Dupont" in text
+        assert "{{ ville }}" in text
+
+    def test_missing_key_generates_warning(self) -> None:
+        renderer = DocxRenderer()
+
+        result = renderer.render(
+            _load_template(),
+            {"nom": "Dupont", "is_admin": True, "items": []},
+        )
+
+        assert "La donnée pour 'ville' n'est pas définie" in result.warnings
+
+    def test_multiple_missing_keys(self) -> None:
+        renderer = DocxRenderer()
+
+        result = renderer.render(_load_template(), {})
+
+        assert any("nom" in w for w in result.warnings)
+        assert any("ville" in w for w in result.warnings)
+
+
+class TestDocxRendererEdgeCases:
+    def test_extra_keys_ignored(self) -> None:
+        renderer = DocxRenderer()
+        data = {**_load_data(), "unknown_key": "ignored"}
+
+        result = renderer.render(_load_template(), data)
+
+        assert result.warnings == []
+        assert "ignored" not in _extract_text(result.content)
+
+    def test_conditional_false_bool_hides_block(self) -> None:
+        """Python `False` is falsy in Jinja — no stringification needed."""
+        renderer = DocxRenderer()
+        data = {**_load_data(), "is_admin": False}
+
+        result = renderer.render(_load_template(), data)
+
+        text = _extract_text(result.content)
+        assert "Vous etes administrateur" not in text
+
+    def test_empty_list_produces_no_items(self) -> None:
+        renderer = DocxRenderer()
+        data = {**_load_data(), "items": []}
+
+        result = renderer.render(_load_template(), data)
+
+        text = _extract_text(result.content)
+        assert "dossier" not in text

--- a/workers/python/pyproject.toml
+++ b/workers/python/pyproject.toml
@@ -163,3 +163,11 @@ test = [
     "pytest>=8.4.2",
 ]
 
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.13"
+include = ["src", "tests"]
+exclude = [".venv", "demo", "generation-render"]
+typeCheckingMode = "off"
+


### PR DESCRIPTION
## Summary
- Nouveau renderer **DOCX** dans le worker `generation-render` (via `docxtpl`), enregistré pour les templates `.docx` — collecte les clés Jinja non définies en warnings au lieu de planter
- Collection **Bruno** pour le service `generation-render` (upload template, création de task, polling status, cas d'erreur "missing keys")
- Cible Make `build-generation-render-worker` (`docker compose build --no-cache generation-render-worker`) — sert aussi de rappel quand une dépendance du worker est ajoutée et que l'image locale doit être reconstruite proprement
- Consolidation de la config **pyright** à la racine (`pyproject.toml`) + alignement sur chaque worker Python

## Test plan
- [ ] `make lint`
- [ ] `make test` (inclut `tests/test_docx_renderer.py`)
- [ ] `make build-generation-render-worker && make up` — le worker démarre `healthy`
- [ ] Dans Bruno : exécuter `01 Upload docx template` → `02 Create render task` → `03 Get task status` → task passe `pending` → `success` avec `output_file_id`
- [ ] `04 Create render task - missing keys` → task `success` avec `warnings` non vide (clés manquantes listées)

🤖 Generated with [Claude Code](https://claude.com/claude-code)